### PR TITLE
add entrypoint logic to allow jar at run

### DIFF
--- a/Dockerfile.beagle
+++ b/Dockerfile.beagle
@@ -1,20 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0
 ARG BASE_IMAGE
-FROM $BASE_IMAGE as builder
+FROM $BASE_IMAGE
+
+ARG RUN_CMD
 
 RUN DEBIAN_FRONTEND=noninteractive apt -y install \
-    wget
-
-WORKDIR /src
-RUN wget http://faculty.washington.edu/browning/beagle/beagle.22Jul22.46e.jar -O beagle.jar
-
-FROM $BASE_IMAGE as release
-
-ARG JAR_PATH=/opt/java/bin
-COPY --from=builder /src/beagle.jar $JAR_PATH/beagle.jar
-RUN chmod 555 $JAR_PATH/beagle.jar
+    apt-utils $RUN_CMD
 
 # Create an entrypoint for the binary
-RUN echo "#!/bin/bash\njava -jar $JAR_PATH/beagle.jar \$@" > /entrypoint.sh && \
+RUN echo "#!/bin/bash\n$RUN_CMD \$@" > /entrypoint.sh && \
 	chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile.beagle
+++ b/Dockerfile.beagle
@@ -2,8 +2,6 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE as builder
 
-ARG RUNCMD
-
 RUN DEBIAN_FRONTEND=noninteractive apt -y install \
     wget
 
@@ -16,6 +14,7 @@ ARG JAR_PATH=/opt/java/bin
 COPY --from=builder /src/beagle.jar $JAR_PATH/beagle.jar
 RUN chmod 555 $JAR_PATH/beagle.jar
 
-WORKDIR /app
-
-ENTRYPOINT [ "java" ]
+# Create an entrypoint for the binary
+RUN echo "#!/bin/bash\njava -jar $JAR_PATH/beagle.jar \$@" > /entrypoint.sh && \
+	chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile.flare
+++ b/Dockerfile.flare
@@ -2,8 +2,6 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE as builder
 
-ARG RUNCMD
-
 RUN DEBIAN_FRONTEND=noninteractive apt -y install \
     git
 
@@ -19,6 +17,7 @@ ARG JAR_PATH=/opt/java/bin
 COPY --from=builder /src/flare.jar $JAR_PATH/flare.jar
 RUN chmod 555 $JAR_PATH/flare.jar
 
-WORKDIR /app
-
-ENTRYPOINT [ "java" ]
+# Create an entrypoint for the binary
+RUN echo "#!/bin/bash\njava -jar $JAR_PATH/flare.jar \$@" > /entrypoint.sh && \
+	chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ $(TOOLS):
 		$(DOCKER_BUILD_ARGS) \
 		-f ./Dockerfile.$@ \
 		--build-arg BASE_IMAGE=$(DOCKER_IMAGE_BASE)/$(DOCKER_BASE) \
-		--build-arg RUNCMD="$@" \
+		--build-arg RUN_CMD=$@ \
 		.
 
 docker_test:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 ORG_NAME := hihg-um
 OS_BASE ?= ubuntu
-OS_VER ?= 22.04
+OS_VER ?= 23.10
 
 IMAGE_REPOSITORY ?=
 DOCKER_IMAGE_BASE := $(ORG_NAME)


### PR DESCRIPTION
adapts the snptest/analytics format for entrypoint, using the entire java -jar command for each jarfile