### PR TITLE
revert change to flare entrypoint

### DIFF
--- a/Dockerfile.flare
+++ b/Dockerfile.flare
@@ -25,5 +25,5 @@ ARG TEST="/test.sh"
 COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
 
 ARG ARG ENTRY="/entrypoint.sh"
-RUN echo "#!/bin/bash\n$RUN_CMD \$@" > ${ENTRY} && chmod ugo+rx ${ENTRY}
+RUN echo "#!/bin/bash\njava -jar ${JAR_PATH}/flare.jar \$@" > ${ENTRY} && chmod ugo+rx ${ENTRY}
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
- the jar file cannot run as a binary, must be invoked with java -jar

quick pr