### PR TITLE
Update Beagle and fix tests

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,27 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    tags-ignore: ["*"]
+  workflow_dispatch:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 'Checkout Actions'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 5
+        fetch-tags: true
+
+    - name: 'Build the Docker image'
+      run: IMAGE_REPO=ghcr.io make docker
+
+    - name: 'Test the Docker image'
+      run: IMAGE_REPO=ghcr.io make docker_test

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,33 @@
+name: Docker Release CI
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+jobs:
+
+  release:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 'Checkout Actions'
+      uses: actions/checkout@v4
+
+    - name: 'Login to GitHub Container Registry'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
+
+    - name: 'Build the Docker image'
+      run: IMAGE_REPO="ghcr.io" make docker
+
+    - name: 'Test the Docker image'
+      run: IMAGE_REPO="ghcr.io" make docker_test
+
+    - name: 'Release the Docker image'
+      run: IMAGE_REPO="ghcr.io" make docker_release

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM $BASE_IMAGE
 
 LABEL org.opencontainers.image.description="Java common base image"
 
+ENV CLASSPATH=/opt/java/bin
+
 # Install OS updates, security fixes and utils, generic app dependencies
 RUN apt -y update -qq && apt -y upgrade && \
 	DEBIAN_FRONTEND=noninteractive apt -y install \

--- a/Dockerfile.beagle
+++ b/Dockerfile.beagle
@@ -2,13 +2,22 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-LABEL org.opencontainers.image.description="Java environment for Beagle. See https://github.com/hihg-um/docker-analytics for a packaged release of Beagle"
-
+ARG BASE_IMAGE
 ARG RUN_CMD
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+LABEL org.opencontainers.image.description="Java environment for Beagle. See https://github.com/hihg-um/docker-analytics for a packaged release of Beagle"
 
-ARG ARG ENTRY="/entrypoint.sh"
-RUN echo "#!/bin/bash\n$RUN_CMD \$@" > ${ENTRY} && chmod ugo+rx ${ENTRY}
-ENTRYPOINT [ "/entrypoint.sh" ]
+WORKDIR ${CLASSPATH}
+
+# https://packages.ubuntu.com/noble/libhtsjdk-java
+# http://faculty.washington.edu/browning/beagle/beagle.27May24.118.jar
+ARG BEAGLE_URL_BASE="http://faculty.washington.edu/browning/beagle"
+ARG BEAGLE_REL=27May24.118
+ARG BEAGLE_JAR=beagle.${BEAGLE_REL}.jar
+RUN curl -sLO "${BEAGLE_URL_BASE}/${BEAGLE_JAR}" && \
+	chmod 0444 ${BEAGLE_JAR} && ln -s ${CLASSPATH}/${BEAGLE_JAR} beagle.jar
+
+COPY --chmod=0555 src/test/$RUN_CMD.sh /test.sh
+COPY --chmod=0555 src/run/$RUN_CMD.sh /
+
+ENTRYPOINT [ "/beagle.sh" ]

--- a/Dockerfile.flare
+++ b/Dockerfile.flare
@@ -13,18 +13,11 @@ RUN git clone https://github.com/hihg-um/flare.git  && \
 	jar -i flare.jar
 
 FROM $BASE_IMAGE
-
 ARG RUN_CMD
-ENV RUN_CMD=${RUN_CMD}
 
-ENV JAR_PATH=/opt/java/bin/flare.jar
-COPY --from=builder /src/flare.jar ${JAR_PATH}
-RUN chmod 555 ${JAR_PATH}
+COPY --from=builder --chmod=0444 /src/flare.jar ${CLASSPATH}/
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+COPY --chmod=0555 src/test/$RUN_CMD.sh /test.sh
+COPY --chmod=0555 src/run/$RUN_CMD.sh /
 
-ARG ARG ENTRY="/entrypoint.sh"
-RUN echo "#!/bin/bash\njava \${JAVA_FLARE_OPTS} -jar ${JAR_PATH} \$@" \
-	> ${ENTRY} && chmod ugo+rx ${ENTRY}
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT [ "/flare.sh" ]

--- a/src/run/beagle.sh
+++ b/src/run/beagle.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0
+#
+java ${JAVA_OPTS_BEAGLE} -jar ${CLASSPATH}/beagle.jar

--- a/src/run/flare.sh
+++ b/src/run/flare.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0
+#
+java ${JAVA_FLARE_OPTS} -jar ${CLASSPATH}/flare.jar

--- a/src/test/beagle.sh
+++ b/src/test/beagle.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0
 
-beagle
+java -jar ${CLASSPATH}/beagle.jar

--- a/src/test/flare.sh
+++ b/src/test/flare.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-
-java -jar $JAR_PATH/flare.jar
+# SPDX-License-Identifier: GPL-3.0
+#
+java -jar ${CLASSPATH}/flare.jar


### PR DESCRIPTION
 - Update to Beagle release 5.4 / 27. May 2024
 - Simplify entrypoint management
 - use common CLASSPATH
 - make tests work correctly

- Add GitHub actions